### PR TITLE
Converted and tidied up for Swift 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/ObserverSet.xcodeproj/project.xcworkspace/xcuserdata
+/ObserverSet.xcodeproj/xcuserdata

--- a/ObserverSet.xcodeproj/project.pbxproj
+++ b/ObserverSet.xcodeproj/project.pbxproj
@@ -336,6 +336,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -355,6 +357,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mikeash.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -374,6 +378,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mikeash.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -389,6 +395,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mikeash.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/ObserverSet/ObserverSet.swift
+++ b/ObserverSet/ObserverSet.swift
@@ -1,92 +1,128 @@
-//
-//  ObserverSet.swift
-//  ObserverSet
-//
-//  Created by Mike Ash on 1/22/15.
-//  Copyright (c) 2015 Mike Ash. All rights reserved.
-//
+/*
+ ObserverSet is distributed under a BSD license, as listed below.
+ 
+ Copyright (c) 2015, Michael Ash
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ 
+ Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ 
+ Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ 
+ Neither the name of Michael Ash nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
-import Foundation
+// Modified by Kane Cheshire on 21 February 2017
 
-public class ObserverSetEntry<Parameters> {
-    private weak var object: AnyObject?
-    private let f: AnyObject -> Parameters -> Void
-    
-    private init(object: AnyObject, f: AnyObject -> Parameters -> Void) {
-        self.object = object
-        self.f = f
-    }
+import Dispatch
+
+/// A reference to an entry in the list of observers. Use this to remove an observer.
+open class ObserverSetEntry<Parameters> {
+  
+  fileprivate weak var observer: AnyObject?
+  fileprivate let callBack: (Any) -> (Parameters) -> Void
+  
+  fileprivate init(observer: AnyObject?, callBack: @escaping (Any) -> (Parameters) -> Void) {
+    self.observer = observer
+    self.callBack = callBack
+  }
+  
 }
 
-public class ObserverSet<Parameters>: CustomStringConvertible {
-    // Locking support
-    
-    private var queue = dispatch_queue_create("com.mikeash.ObserverSet", nil)
-    
-    private func synchronized(f: Void -> Void) {
-        dispatch_sync(queue, f)
+/// A set of observers that can be notified of certain actions. A more Swift-like version of NSNotificationCenter.
+open class ObserverSet<Parameters> {
+  
+  // MARK: - Private properties
+  
+  private var entries: [ObserverSetEntry<Parameters>] = []
+  
+  // MARK: - Initialisers
+  
+  /**
+   Creates a new instance of an observer set.
+   
+   - returns: A new instance of an observer set.
+   */
+  public init() {}
+  
+  // MARK: - Public functions
+  
+  /**
+   Adds a new observer to the set.
+   
+   - parameter observer: The object that is to be notified.
+   - parameter callBack: The function to call on the observer when the notification is to be delivered.
+   
+   - returns: An entry in the list of observers, which can be used later to remove the observer.
+   */
+  @discardableResult
+  open func add<ObserverType: AnyObject>(_ observer: ObserverType, _ callBack: @escaping (ObserverType) -> (Parameters) -> Void) -> ObserverSetEntry<Parameters> {
+    let entry = ObserverSetEntry<Parameters>(observer: observer) { observer in callBack(observer as! ObserverType) }
+    synchronized {
+      self.entries.append(entry)
     }
-    
-    
-    // Main implementation
-    
-    private var entries: [ObserverSetEntry<Parameters>] = []
-    
-    public init() {}
-    
-    public func add<T: AnyObject>(object: T, _ f: T -> Parameters -> Void) -> ObserverSetEntry<Parameters> {
-        let entry = ObserverSetEntry<Parameters>(object: object, f: { f($0 as! T) })
-        synchronized {
-            self.entries.append(entry)
-        }
-        return entry
+    return entry
+  }
+  
+  /**
+   Adds a new function to the list of functions to invoke when a notification is to be delivered.
+   
+   - parameter callBack: The function to call when the notification is to be delivered.
+   
+   - returns: An entry in the list of observers, which can be used later to remove the observer.
+   */
+  @discardableResult
+  open func add(_ callBack: @escaping (Parameters) -> Void) -> ObserverSetEntry<Parameters> {
+    return self.add(self) { ignored in callBack }
+  }
+  
+  /**
+   Removes an observer from the list, using the entry which was returned when adding.
+   
+   - parameter entry: An entry returned when adding a new observer.
+   */
+  open func remove(_ entry: ObserverSetEntry<Parameters>) {
+    synchronized {
+      self.entries = self.entries.filter{ $0 !== entry }
     }
-    
-    public func add(f: Parameters -> Void) -> ObserverSetEntry<Parameters> {
-        return self.add(self, { ignored in f })
+  }
+  
+  /**
+   Call this method to notify all observers.
+   
+   - parameter parameters: The parameters that are required parameters specified using generics when the instance is created.
+   */
+  open func notify(_ parameters: Parameters) {
+    var callBackList: [(Parameters) -> Void] = []
+    synchronized {
+      for entry in self.entries {
+        if let observer = entry.observer {
+          callBackList.append(entry.callBack(observer))
+        }
+      }
+      self.entries = self.entries.filter{ $0.observer != nil }
     }
-    
-    public func remove(entry: ObserverSetEntry<Parameters>) {
-        synchronized {
-            self.entries = self.entries.filter{ $0 !== entry }
-        }
+    for callBack in callBackList {
+      callBack(parameters)
     }
-    
-    public func notify(parameters: Parameters) {
-        var toCall: [Parameters -> Void] = []
-        
-        synchronized {
-            for entry in self.entries {
-                if let object: AnyObject = entry.object {
-                    toCall.append(entry.f(object))
-                }
-            }
-            self.entries = self.entries.filter{ $0.object != nil }
-        }
-        
-        for f in toCall {
-            f(parameters)
-        }
-    }
-    
-    
-    // MARK: CustomStringConvertible
-    
-    public var description: String {
-        var entries: [ObserverSetEntry<Parameters>] = []
-        synchronized {
-            entries = self.entries
-        }
-        
-        let strings = entries.map{
-            entry in
-            (entry.object === self
-                ? "\(entry.f)"
-                : "\(entry.object) \(entry.f)")
-        }
-        let joined = strings.joinWithSeparator(", ")
-        
-        return "\(Mirror(reflecting: self).description): (\(joined))"
-    }
+  }
+  
+  // MARK: - Private functions
+  // MARK: Locking support
+  
+  private var queue = DispatchQueue(label: "com.theappbusiness.ObserverSet", attributes: [])
+  
+  private func synchronized(_ f: (Void) -> Void) {
+    queue.sync(execute: f)
+  }
+  
 }
-

--- a/ObserverSetTests/CaptureSemanticsTests.swift
+++ b/ObserverSetTests/CaptureSemanticsTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import ObserverSet
+@testable import ObserverSet
 
 class CaptureSemanticsTests: XCTestCase {
     
@@ -32,7 +32,7 @@ class CaptureSemanticsTests: XCTestCase {
         let observee = TestObservee()
         
         init() {
-            observee.event.add(self, self.dynamicType.voidHandler)
+            observee.event.add(self, type(of: self).voidHandler)
         }
         
         func voidHandler() {

--- a/ObserverSetTests/ObserverSetTests.swift
+++ b/ObserverSetTests/ObserverSetTests.swift
@@ -12,6 +12,7 @@ import XCTest
 import ObserverSet
 
 class ObserverSetTests: XCTestCase {
+  
     class TestObservee {
         let voidObservers = ObserverSet<Void>()
         let stringObservers = ObserverSet<String>()
@@ -32,12 +33,12 @@ class ObserverSetTests: XCTestCase {
     
     class TestObserver {
         init(observee: TestObservee) {
-            observee.voidObservers.add(self, self.dynamicType.voidSent)
-            observee.stringObservers.add(self, self.dynamicType.stringChanged)
-            observee.twoStringObservers.add(self, self.dynamicType.twoStringChanged)
-            observee.intObservers.add(self, self.dynamicType.intChanged)
-            observee.intAndStringObservers.add(self, self.dynamicType.intAndStringChanged)
-            observee.namedParameterObservers.add(self, self.dynamicType.namedParameterSent)
+            observee.voidObservers.add(self, type(of: self).voidSent)
+            observee.stringObservers.add(self, type(of: self).stringChanged)
+            observee.twoStringObservers.add(self, type(of: self).twoStringChanged)
+            observee.intObservers.add(self, type(of: self).intChanged)
+            observee.intAndStringObservers.add(self, type(of: self).intAndStringChanged)
+            observee.namedParameterObservers.add(self, type(of: self).namedParameterSent)
         }
         
         deinit {
@@ -72,17 +73,12 @@ class ObserverSetTests: XCTestCase {
     func testBasics() {
         let observee = TestObservee()
         var obj: TestObserver? = TestObserver(observee: observee)
-        
         let token = observee.intAndStringObservers.add{ print("int and string closure: \($0) \($1)") }
-        print("intAndStringObservers: \(observee.intAndStringObservers.description)")
-        
         observee.testNotify()
         print("Destroying test observer \(obj)")
         obj = nil
         observee.testNotify()
         observee.intAndStringObservers.remove(token)
         observee.testNotify()
-        
-        print("intAndStringObservers: \(observee.intAndStringObservers.description)")
     }
 }


### PR DESCRIPTION
- Updated for Swift 3
- Removes conformance to `CustomStringConvertable` as it just adds noise, unless anyone uses this I think we should remove it.
- Turns on "warnings as errors" for the main target