### PR TITLE
Add remove by observer

### DIFF
--- a/Example/Tests/ObserverSetTests.swift
+++ b/Example/Tests/ObserverSetTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import TABObserverSet
 
 class ObserverSetTests: XCTestCase {
-  
+    
     class TestObservee {
         let voidObservers = ObserverSet<Void>()
         let stringObservers = ObserverSet<String>()
@@ -30,10 +30,10 @@ class ObserverSetTests: XCTestCase {
     }
     
     class TestObserver {
-		
-		var stringNotificationsReceived = [String]()
-		var twoStringNotificationsReceived = [(String, String)]()
-		
+        
+        var stringNotificationsReceived = [String]()
+        var twoStringNotificationsReceived = [(String, String)]()
+        
         init(observee: TestObservee) {
             observee.voidObservers.add(self, type(of: self).voidSent)
             observee.stringObservers.add(self, type(of: self).stringChanged)
@@ -53,12 +53,12 @@ class ObserverSetTests: XCTestCase {
         
         func stringChanged(s: String) {
             print("stringChanged: " + s)
-			stringNotificationsReceived.append(s)
+            stringNotificationsReceived.append(s)
         }
         
         func twoStringChanged(s1: String, s2: String) {
             print("twoStringChanged: \(s1) \(s2)")
-			twoStringNotificationsReceived.append(s1, s2)
+            twoStringNotificationsReceived.append(s1, s2)
         }
         
         func intChanged(i: Int, j: Int) {
@@ -85,16 +85,16 @@ class ObserverSetTests: XCTestCase {
         observee.intAndStringObservers.remove(token)
         observee.testNotify()
     }
-	
-	func testRemoveObserver() {
-		let sut = TestObservee()
-		let observer = TestObserver(observee: sut)
-		sut.testNotify()
-		XCTAssertEqual(observer.stringNotificationsReceived, ["Sup"])
-		XCTAssertTrue(observer.twoStringNotificationsReceived.elementsEqual([("hello", "world")], by: ==))
-		sut.twoStringObservers.removeObserver(observer)
-		sut.testNotify()
-		XCTAssertEqual(observer.stringNotificationsReceived, ["Sup", "Sup"])
-		XCTAssertTrue(observer.twoStringNotificationsReceived.elementsEqual([("hello", "world")], by: ==))
-	}
+    
+    func testRemoveObserver() {
+        let sut = TestObservee()
+        let observer = TestObserver(observee: sut)
+        sut.testNotify()
+        XCTAssertEqual(observer.stringNotificationsReceived, ["Sup"])
+        XCTAssertTrue(observer.twoStringNotificationsReceived.elementsEqual([("hello", "world")], by: ==))
+        sut.twoStringObservers.removeObserver(observer)
+        sut.testNotify()
+        XCTAssertEqual(observer.stringNotificationsReceived, ["Sup", "Sup"])
+        XCTAssertTrue(observer.twoStringNotificationsReceived.elementsEqual([("hello", "world")], by: ==))
+    }
 }

--- a/Example/Tests/ObserverSetTests.swift
+++ b/Example/Tests/ObserverSetTests.swift
@@ -30,6 +30,10 @@ class ObserverSetTests: XCTestCase {
     }
     
     class TestObserver {
+		
+		var stringNotificationsReceived = [String]()
+		var twoStringNotificationsReceived = [(String, String)]()
+		
         init(observee: TestObservee) {
             observee.voidObservers.add(self, type(of: self).voidSent)
             observee.stringObservers.add(self, type(of: self).stringChanged)
@@ -49,10 +53,12 @@ class ObserverSetTests: XCTestCase {
         
         func stringChanged(s: String) {
             print("stringChanged: " + s)
+			stringNotificationsReceived.append(s)
         }
         
         func twoStringChanged(s1: String, s2: String) {
             print("twoStringChanged: \(s1) \(s2)")
+			twoStringNotificationsReceived.append(s1, s2)
         }
         
         func intChanged(i: Int, j: Int) {
@@ -79,4 +85,16 @@ class ObserverSetTests: XCTestCase {
         observee.intAndStringObservers.remove(token)
         observee.testNotify()
     }
+	
+	func testRemoveObserver() {
+		let sut = TestObservee()
+		let observer = TestObserver(observee: sut)
+		sut.testNotify()
+		XCTAssertEqual(observer.stringNotificationsReceived, ["Sup"])
+		XCTAssertTrue(observer.twoStringNotificationsReceived.elementsEqual([("hello", "world")], by: ==))
+		sut.twoStringObservers.removeObserver(observer)
+		sut.testNotify()
+		XCTAssertEqual(observer.stringNotificationsReceived, ["Sup", "Sup"])
+		XCTAssertTrue(observer.twoStringNotificationsReceived.elementsEqual([("hello", "world")], by: ==))
+	}
 }

--- a/ObserverSet.swift
+++ b/ObserverSet.swift
@@ -96,6 +96,18 @@ open class ObserverSet<Parameters> {
     }
   }
   
+
+  /**
+   Removes an observer from the list.
+
+   - parameter observer: An observer to remove from the list of observers.
+   */
+  open func removeObserver(_ observer: AnyObject) {
+    synchronized {
+      self.entries = self.entries.filter{ $0.observer !== observer }
+    }
+  }
+
   /**
    Call this method to notify all observers.
    


### PR DESCRIPTION
Usage is the same as `NotificationCenter.removeObserver`. 

It means that you don’t have to store the token if you want to remove an observer